### PR TITLE
BREAKING: Remove tests on node 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "node"
-  - "11"
   - "10"
   - "8"
 


### PR DESCRIPTION
Update the test setup to run on current node versions. The current
versions are 8, 10 and 12.

This commit drops support for node 11.