### PR TITLE
Fix types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,4 +42,4 @@ const getRelativeLuminance = (
   return L
 }
 
-export default getRelativeLuminance
+export = getRelativeLuminance


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports.

The last line should be `export = getRelativeLuminance` since your package is CommonJS.